### PR TITLE
Clarify the vendor config publish step is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Set your Mailchimp API Key in your `.env` file. You can get it from: https://us1
 MAILCHIMP_API_KEY=your-key-here
 ```
 
-Publish the config file to `config/mailchimp.php` run:
+**NOTE: This addon saves its settings to the file `config/mailchimp.php`**
+To initialize the *required* config file run:
 
 ```bash
 php artisan vendor:publish --tag="mailchimp-config"


### PR DESCRIPTION
This adds a little clarity to the fact the vendor config publish step is required.

Without this clarification one (including myself an hour ago) might assume that this package - like most other Laravel/Statamic packages - merely provides an option to publish the config and that it is not required.

Feel free to change the wording - I only claim to be a coder not a wordsmith :)