### PR TITLE
Pass form handle to subscribe function

### DIFF
--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -33,6 +33,8 @@ class Subscriber
             return null;
         }
 
+        $config['form'] = $form->handle();
+
         return new self($submission->data(), $config);
     }
 

--- a/tests/Unit/SubscriberFromSubmissionTest.php
+++ b/tests/Unit/SubscriberFromSubmissionTest.php
@@ -207,6 +207,7 @@ class SubscriberFromSubmissionTest extends TestCase
                 ],
             ],
             'primary_email_field' => 'email',
+            'form' => 'contact_us',
         ];
 
         $this->form->merge([


### PR DESCRIPTION
In the switch to the new config the form is no longer defined (oops) so this ensure it gets passed.

Closes #128 