### PR TITLE
Add placeholders to v-select in custom fieldtypes

### DIFF
--- a/resources/js/components/fieldtypes/FormFieldsFieldtype.vue
+++ b/resources/js/components/fieldtypes/FormFieldsFieldtype.vue
@@ -9,6 +9,7 @@
             :clearable="true"
             :options="fields"
             :reduce="(option) => option.id"
+            :placeholder="__('Choose...')"
             :searchable="true"
             @input="$emit('input', $event)"
         />

--- a/resources/js/components/fieldtypes/MailchimpMergeFieldsFieldtype.vue
+++ b/resources/js/components/fieldtypes/MailchimpMergeFieldsFieldtype.vue
@@ -9,6 +9,7 @@
             :clearable="true"
             :options="fields"
             :reduce="(option) => option.id"
+            :placeholder="__('Choose...')"
             :searchable="true"
             @input="$emit('input', $event)"
         />

--- a/resources/js/components/fieldtypes/MailchimpTagFieldtype.vue
+++ b/resources/js/components/fieldtypes/MailchimpTagFieldtype.vue
@@ -9,6 +9,7 @@
             :clearable="true"
             :options="tags"
             :reduce="(option) => option.id"
+            :placeholder="__('Choose...')"
             :searchable="true"
             @input="$emit('input', $event)"
         />

--- a/resources/js/components/fieldtypes/UserFieldsFieldtype.vue
+++ b/resources/js/components/fieldtypes/UserFieldsFieldtype.vue
@@ -6,6 +6,7 @@
             :clearable="true"
             :options="fields"
             :reduce="(option) => option.id"
+            :placeholder="__('Choose...')"
             :searchable="true"
             @input="$emit('input', $event)"
         />


### PR DESCRIPTION
Adds v-select placeholders to match Statamic core fieldtypes.

Before
<img width="910" alt="Screenshot 2025-05-06 at 16 16 10" src="https://github.com/user-attachments/assets/d9b8e894-db24-4394-adf4-d127a029ec10" />

After
<img width="910" alt="Screenshot 2025-05-06 at 16 22 46" src="https://github.com/user-attachments/assets/91c788f6-90c0-4cac-a0e7-75f335d9afbc" />
