### PR TITLE
Update dependences for only Laravel 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            framework: ^11.0
-            testbench: 9.*
           - laravel: 12.*
             framework: ^12.0
             testbench: 10.*

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         "jasonmccreary/laravel-test-assertions": "^2.0",
         "laravel/pint": "^1.17",
         "mockery/mockery": "^1.3.1",
-        "nunomaduro/collision": "^7.0 || ^8.0",
-        "orchestra/testbench": "^9.0 || ^10.0",
-        "orchestra/testbench-core": "^9.2 || ^10.0",
-        "phpunit/phpunit": "^10.0 || ^11.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^10.0",
+        "orchestra/testbench-core": "^10.0",
+        "phpunit/phpunit": "^11.0",
         "spatie/laravel-ray": "^1.4"
     },
     "autoload": {


### PR DESCRIPTION
Update dependencies to only support Laravel 12, like Statamic