### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-action-updater.yml
+++ b/.github/workflows/gh-action-updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -7,6 +7,6 @@ jobs:
   pr-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v4
+      - uses: TimonVS/pr-labeler-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       release_upload_url: ${{ steps.latest_draft_release.outputs.upload_url }}
     steps:
       - name: Get Draft Release
-        uses: cardinalby/git-get-release-action@v1
+        uses: cardinalby/git-get-release-action@1.2.4
         id: latest_draft_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install dependencies
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@v6.1.2
         with:
             php_version: "8.4"
 
@@ -42,7 +42,7 @@ jobs:
         run: tar -czvf dist.tar.gz dist
 
       - name: Upload zip to release
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -56,20 +56,20 @@ jobs:
     needs: get_draft_release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
       - name: Update Changelog
         id: update_changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@v1.12.0
         with:
           latest-version: ${{ needs.get_draft_release.outputs.release_tag }}
           release-notes: ${{ needs.get_draft_release.outputs.release_body }}
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
           branch: main
           commit_message: Update CHANGELOG
           file_pattern: CHANGELOG.md
-      - uses: eregon/publish-release@v1
+      - uses: eregon/publish-release@v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,16 @@ jobs:
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
             path: ~/.composer/cache/files
             key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.36.0
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)** published a new release **[v6.2.0](https://github.com/release-drafter/release-drafter/releases/tag/v6.2.0)** on 2026-01-22T09:49:31Z
* **[shivammathur/setup-php](https://github.com/shivammathur/setup-php)** published a new release **[2.36.0](https://github.com/shivammathur/setup-php/releases/tag/2.36.0)** on 2025-11-26T11:30:22Z
* **[stefanzweifel/changelog-updater-action](https://github.com/stefanzweifel/changelog-updater-action)** published a new release **[v1.12.0](https://github.com/stefanzweifel/changelog-updater-action/releases/tag/v1.12.0)** on 2024-11-16T09:20:36Z
* **[cardinalby/git-get-release-action](https://github.com/cardinalby/git-get-release-action)** published a new release **[1.2.4](https://github.com/cardinalby/git-get-release-action/releases/tag/1.2.4)** on 2022-11-02T22:40:20Z
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v7.1.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v7.1.0)** on 2025-12-17T19:25:45Z
* **[eregon/publish-release](https://github.com/eregon/publish-release)** published a new release **[v1.0.6](https://github.com/eregon/publish-release/releases/tag/v1.0.6)** on 2024-02-17T11:24:08Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v5.0.3](https://github.com/actions/cache/releases/tag/v5.0.3)** on 2026-01-29T09:51:30Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[actions/upload-release-asset](https://github.com/actions/upload-release-asset)** published a new release **[v1.0.2](https://github.com/actions/upload-release-asset/releases/tag/v1.0.2)** on 2020-02-10T08:01:38Z
* **[php-actions/composer](https://github.com/php-actions/composer)** published a new release **[v6.1.2](https://github.com/php-actions/composer/releases/tag/v6.1.2)** on 2023-10-11T22:15:30Z
* **[TimonVS/pr-labeler-action](https://github.com/TimonVS/pr-labeler-action)** published a new release **[v5.0.0](https://github.com/TimonVS/pr-labeler-action/releases/tag/v5.0.0)** on 2024-02-09T10:35:32Z
